### PR TITLE
chore(rust): const_fn is stable now

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,6 @@
 
 #![no_std]
 #![deny(missing_docs)]
-#![feature(const_fn)]
 #![doc(html_root_url = "https://docs.rs/unflappable/0.1.0")]
 
 use core::cell::UnsafeCell;


### PR DESCRIPTION
Builds and tests pass on:

```
stable-x86_64-apple-darwin (default)
rustc 1.68.2 (9eb3afe9e 2023-03-27)
```